### PR TITLE
Added naming rules for interface, class, exception.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,16 @@ This page list all agreed coding standards adopted at EncoreTickets for each PHP
 
 Anyone can suggest a change for this page by submitting a Github pull requests that will need to be discussed and voted by all current developers in order to obtain an agreement by the majority.
 
+## Naming Conventions
+
+This section is talking about the adopted naming conventions.
+
+#### Interface, Class, Exception, Traits naming: 
+- Prefix abstract classes with ***Abstract***;
+- Suffix interfaces with ***Interface***;
+- Suffix traits with ***Trait***;
+- Suffix exceptions with ***Exception***;
+
 ## Coding style
 
 This section is talking about the adopted coding styles, we're currently using PHP-CS-FIXER to detect any violation of the following rules


### PR DESCRIPTION
# PHP-CS: Naming Conventions

## Introduction
Update class naming convention, to use required suffix 'Interface', 'Exception', 'Traits' and prefix 'Abstract'. According to symfony coding guide: https://symfony.com/doc/current/contributing/code/standards.html#naming-conventions.

## Proposal with  examples usage
- Prefix abstract classes with ***Abstract***;
- Suffix interfaces with ***Interface***;
- Suffix traits with ***Trait***;
- Suffix exceptions with ***Exception***;

```php
<?php

    interface  GatewayInterface {
    }

    class  MessageContentException {
    }

    abstract class AbstractProduct {
    }

```

## Benefits
- Improve code readability and understanding
- Сomply with symfony coding guide

## Proposed Voting Choices
2/3 of developers should be agree with it.
