### PR TITLE
Added declare strict types rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,15 @@ array('value');
 // Now
 ['value'];
 ```
+
+### declare_strict_types = true
+
+Force strict types declaration in all files. Requires PHP >= 7.0.
+
+Risky rule: forcing strict types will stop non strict code from working.
+
+```php
+<?php
+
+declare(strict_types=1);
+```


### PR DESCRIPTION
# PHP-CS: Declare strict types rule

## Introduction
Update cs fixer rule for forcing add declare(strict_types=1) to all files.

## Proposal
In all PHP >= 7.0 files we should use delare strict type for decreasing errors in application.
```php
<?php

declare(strict_types=1);
```

## Benefits
Decrease type errors in applications.
