### PR TITLE
Added rule for naming classes and namespaces that is abbreviations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,19 @@ Risky rule: forcing strict types will stop non strict code from working.
 
 declare(strict_types=1);
 ```
+
+### Class (Namespace) naming
+
+Use camel case for each separate semantic unit, including abbreviation, e.g.:
+XI -> Xi
+Data Transfer Object -> DTO -> Dto
+
+Classes:
+- TT API -> TtApi
+- US Tax -> UsTax
+NOTE: we still have E.API that usually understood as Entertain API that's why EApi
+
+Namespases:
+- App\Dto\Item
+- App\Gateway\TtApi
+


### PR DESCRIPTION
# PHP-CS: Naming rule for classes and namespaces for abbreviations

## Introduction
Quite important to keep variable, class and namespaces meaningful and at the same time shorter. Abbreviations one of the way to make them short, but living them in capital case adds some confusion also.

## Proposal with an example usage
Consider abbreviations as separate semantic unit and use camel case for them.  Abbreviation description highly desired.
```php
<?php

/**
 * TodayTix API.
 */
class TtApi
{
...
```

## Benefits
* Variables, class names, namespaces, etc. are quite short with abbreviations
* Following general abbreviations handling rules brings less confusion

## Proposed Voting Choices
Approve or disapprove
